### PR TITLE
Change of all version to WND.

### DIFF
--- a/openscoring-client/pom.xml
+++ b/openscoring-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openscoring</groupId>
 		<artifactId>openscoring</artifactId>
-		<version>1.3-SNAPSHOT</version>
+		<version>1.3-WND-1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openscoring</groupId>

--- a/openscoring-common-gwt/pom.xml
+++ b/openscoring-common-gwt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openscoring</groupId>
 		<artifactId>openscoring</artifactId>
-		<version>1.3-SNAPSHOT</version>
+		<version>1.3-WND-1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openscoring</groupId>

--- a/openscoring-common/pom.xml
+++ b/openscoring-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openscoring</groupId>
 		<artifactId>openscoring</artifactId>
-		<version>1.3-SNAPSHOT</version>
+		<version>1.3-WND-1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openscoring</groupId>

--- a/openscoring-server/pom.xml
+++ b/openscoring-server/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openscoring</groupId>
 		<artifactId>openscoring</artifactId>
-		<version>1.3-SNAPSHOT</version>
+		<version>1.3-WND-1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openscoring</groupId>

--- a/openscoring-service/pom.xml
+++ b/openscoring-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openscoring</groupId>
 		<artifactId>openscoring</artifactId>
-		<version>1.3-SNAPSHOT</version>
+		<version>1.3-WND-1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openscoring</groupId>

--- a/openscoring-webapp/pom.xml
+++ b/openscoring-webapp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openscoring</groupId>
 		<artifactId>openscoring</artifactId>
-		<version>1.3-SNAPSHOT</version>
+		<version>1.3-WND-1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openscoring</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.openscoring</groupId>
 	<artifactId>openscoring</artifactId>
-	<version>1.3-SNAPSHOT</version>
+	<version>1.3-WND-1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Openscoring</name>
@@ -57,32 +57,32 @@
 			<dependency>
 				<groupId>org.openscoring</groupId>
 				<artifactId>openscoring-client</artifactId>
-				<version>1.3-SNAPSHOT</version>
+				<version>1.3-WND-1-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openscoring</groupId>
 				<artifactId>openscoring-common</artifactId>
-				<version>1.3-SNAPSHOT</version>
+				<version>1.3-WND-1-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openscoring</groupId>
 				<artifactId>openscoring-common-gwt</artifactId>
-				<version>1.3-SNAPSHOT</version>
+				<version>1.3-WND-1-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openscoring</groupId>
 				<artifactId>openscoring-server</artifactId>
-				<version>1.3-SNAPSHOT</version>
+				<version>1.3-WND-1-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openscoring</groupId>
 				<artifactId>openscoring-service</artifactId>
-				<version>1.3-SNAPSHOT</version>
+				<version>1.3-WND-1-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openscoring</groupId>
 				<artifactId>openscoring-webapp</artifactId>
-				<version>1.3-SNAPSHOT</version>
+				<version>1.3-WND-1-SNAPSHOT</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
All openscoring versions changes in pom.xml, versioning schema is now:

{original_version}-WND-{wandera_version}[-SNAPSHOT]
Example:
1.3-WND-1-SNAPSHOT //snapshot of first wandera version based on original version 1.3
1.3-WND-2 //release of wandera version based on original version 1.3
1.4-WND-3 //next release, rebased on original version 1.4 